### PR TITLE
Create FastAPI application with basic project structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /code
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the content of the local src directory to the working directory
+COPY ./app /code/app
+
+# Command to run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
This commit introduces a basic FastAPI application with the following features:

- A standard project structure with `app` and `tests` directories.
- A FastAPI application with a root endpoint and a `/health` endpoint.
- A `requirements.txt` file with the necessary dependencies.
- A `Dockerfile` to containerize the application.
- A test for the health check endpoint.